### PR TITLE
[Feat] 회원 프로필 수정 기능 구현

### DIFF
--- a/src/main/kotlin/team/b5/moviezip/member/controller/MemberController.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/controller/MemberController.kt
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
-import team.b5.moviezip.member.dto.request.SignupRequest
+import team.b5.moviezip.member.dto.request.MemberRequest
 import team.b5.moviezip.member.service.MemberService
 import java.net.URI
 
@@ -16,11 +16,11 @@ class MemberController(
 ) {
     // 회원가입
     @PostMapping("/signup")
-    fun signup(@RequestBody signupRequest: SignupRequest) =
-        ResponseEntity.created(URI.create("/")).body(memberService.signup(signupRequest))
+    fun signup(@RequestBody memberRequest: MemberRequest) =
+        ResponseEntity.created(URI.create("/")).body(memberService.signup(memberRequest))
 
     // 프로필 수정
     @PutMapping("/members/{memberId}")
-    fun update(@RequestBody signupRequest: SignupRequest, @PathVariable memberId: Long) =
-        ResponseEntity.ok().body(memberService.update(signupRequest, memberId))
+    fun update(@RequestBody memberRequest: MemberRequest, @PathVariable memberId: Long) =
+        ResponseEntity.ok().body(memberService.update(memberRequest, memberId))
 }

--- a/src/main/kotlin/team/b5/moviezip/member/controller/MemberController.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/controller/MemberController.kt
@@ -1,7 +1,9 @@
 package team.b5.moviezip.member.controller
 
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import team.b5.moviezip.member.dto.request.SignupRequest
@@ -16,4 +18,9 @@ class MemberController(
     @PostMapping("/signup")
     fun signup(@RequestBody signupRequest: SignupRequest) =
         ResponseEntity.created(URI.create("/")).body(memberService.signup(signupRequest))
+
+    // 프로필 수정
+    @PutMapping("/members/{memberId}")
+    fun update(@RequestBody signupRequest: SignupRequest, @PathVariable memberId: Long) =
+        ResponseEntity.ok().body(memberService.update(signupRequest, memberId))
 }

--- a/src/main/kotlin/team/b5/moviezip/member/dto/request/MemberRequest.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/dto/request/MemberRequest.kt
@@ -8,7 +8,7 @@ import team.b5.moviezip.member.model.Member
 import team.b5.moviezip.member.model.MemberRole
 import team.b5.moviezip.member.model.MemberStatus
 
-data class SignupRequest(
+data class MemberRequest(
     @field:NotBlank(message = "사용자 이름은 필수 항목입니다.")
     val name: String,
 

--- a/src/main/kotlin/team/b5/moviezip/member/model/Member.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/model/Member.kt
@@ -2,7 +2,7 @@ package team.b5.moviezip.member.model
 
 import jakarta.persistence.*
 import team.b5.moviezip.global.model.BaseEntity
-import team.b5.moviezip.member.dto.request.SignupRequest
+import team.b5.moviezip.member.dto.request.MemberRequest
 
 @Entity
 @Table(name = "Members")
@@ -32,10 +32,10 @@ class Member(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
 
-    fun update(signupRequest: SignupRequest) {
-        this.name = signupRequest.name
-        this.email = signupRequest.email
-        this.nickname = signupRequest.nickname
-        this.password = signupRequest.password
+    fun update(memberRequest: MemberRequest) {
+        this.name = memberRequest.name
+        this.email = memberRequest.email
+        this.nickname = memberRequest.nickname
+        this.password = memberRequest.password
     }
 }

--- a/src/main/kotlin/team/b5/moviezip/member/model/Member.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/model/Member.kt
@@ -2,6 +2,7 @@ package team.b5.moviezip.member.model
 
 import jakarta.persistence.*
 import team.b5.moviezip.global.model.BaseEntity
+import team.b5.moviezip.member.dto.request.SignupRequest
 
 @Entity
 @Table(name = "Members")
@@ -11,16 +12,16 @@ class Member(
     val role: MemberRole,
 
     @Column(name = "name", nullable = false)
-    val name: String,
+    var name: String,
 
     @Column(name = "nickname", nullable = false)
-    val nickname: String,
+    var nickname: String,
 
     @Column(name = "email", nullable = false)
-    val email: String,
+    var email: String,
 
     @Column(name = "password", nullable = false)
-    val password: String,
+    var password: String,
 
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
@@ -30,4 +31,11 @@ class Member(
     @Column(name = "member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
+
+    fun update(signupRequest: SignupRequest) {
+        this.name = signupRequest.name
+        this.email = signupRequest.email
+        this.nickname = signupRequest.nickname
+        this.password = signupRequest.password
+    }
 }

--- a/src/main/kotlin/team/b5/moviezip/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/repository/MemberRepository.kt
@@ -8,4 +8,6 @@ import team.b5.moviezip.member.model.Member
 interface MemberRepository : JpaRepository<Member, Long> {
     fun existsByNickname(nickname: String): Boolean
     fun existsByEmail(email: String): Boolean
+    fun findByNickname(nickname: String): Member
+    fun findByEmail(email: String): Member
 }

--- a/src/main/kotlin/team/b5/moviezip/member/service/MemberService.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/service/MemberService.kt
@@ -4,7 +4,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import team.b5.moviezip.member.dto.request.SignupRequest
+import team.b5.moviezip.member.dto.request.MemberRequest
 import team.b5.moviezip.member.repository.MemberRepository
 
 @Service
@@ -14,24 +14,33 @@ class MemberService(
     private val passwordEncoder: PasswordEncoder
 ) {
     // 회원가입
-    fun signup(signupRequest: SignupRequest) =
-        signupRequest.let {
-            validateSignupRequest(it)
+    fun signup(memberRequest: MemberRequest) =
+        memberRequest.let {
+            validateRequest(it)
             memberRepository.save(it.to(passwordEncoder))
         }
 
     // 프로필 수정
-    fun update(signupRequest: SignupRequest, memberId: Long) =
-        signupRequest.let {
-            validateSignupRequest(it)
+    fun update(memberRequest: MemberRequest, memberId: Long) =
+        memberRequest.let {
+            validateRequest(it, memberId)
             getMember(memberId).update(it)
         }
 
     // 회원가입 검증
-    private fun validateSignupRequest(signupRequest: SignupRequest) {
-        if (memberRepository.existsByNickname(signupRequest.nickname)) throw Exception("") // TODO
-        else if (memberRepository.existsByEmail(signupRequest.email)) throw Exception("") // TODO
-        else if (signupRequest.password != signupRequest.password2) throw Exception("") // TODO
+    private fun validateRequest(memberRequest: MemberRequest) {
+        if (memberRepository.existsByNickname(memberRequest.nickname)) throw Exception("") // TODO
+        else if (memberRepository.existsByEmail(memberRequest.email)) throw Exception("") // TODO
+        else if (memberRequest.password != memberRequest.password2) throw Exception("") // TODO
+    }
+
+    // 프로필 수정 시 검증 (본인이 기존에 사용하던 nickname, email은 검증 대상에서 제외)
+    private fun validateRequest(memberRequest: MemberRequest, memberId: Long) {
+        if (memberRepository.existsByNickname(memberRequest.nickname) && memberRepository.findByNickname(memberRequest.nickname).id != memberId)
+            throw Exception("") // TODO
+        else if (memberRepository.existsByEmail(memberRequest.email) && memberRepository.findByEmail(memberRequest.email).id != memberId)
+            throw Exception("") // TODO
+        else if (memberRequest.password != memberRequest.password2) throw Exception("") // TODO
     }
 
     // 회원 조회

--- a/src/main/kotlin/team/b5/moviezip/member/service/MemberService.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/service/MemberService.kt
@@ -1,11 +1,14 @@
 package team.b5.moviezip.member.service
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import team.b5.moviezip.member.dto.request.SignupRequest
 import team.b5.moviezip.member.repository.MemberRepository
 
 @Service
+@Transactional
 class MemberService(
     private val memberRepository: MemberRepository,
     private val passwordEncoder: PasswordEncoder
@@ -17,10 +20,21 @@ class MemberService(
             memberRepository.save(it.to(passwordEncoder))
         }
 
+    // 프로필 수정
+    fun update(signupRequest: SignupRequest, memberId: Long) =
+        signupRequest.let {
+            validateSignupRequest(it)
+            getMember(memberId).update(it)
+        }
+
     // 회원가입 검증
     private fun validateSignupRequest(signupRequest: SignupRequest) {
         if (memberRepository.existsByNickname(signupRequest.nickname)) throw Exception("") // TODO
         else if (memberRepository.existsByEmail(signupRequest.email)) throw Exception("") // TODO
         else if (signupRequest.password != signupRequest.password2) throw Exception("") // TODO
     }
+
+    // 회원 조회
+    private fun getMember(memberId: Long) =
+        memberRepository.findByIdOrNull(memberId) ?: throw Exception("") // TODO
 }


### PR DESCRIPTION
## 연관된 이슈

#11 

## 작업 내용

- [ ] MemberController와 MemberSerivce에 update 메서드 추가
- [ ] Member 엔티티에 update 메서드 추가
- [ ] 프로필 수정 시 본인이 기존에 사용하던 nickname과 email은 검증 대상에서 제외하는 로직 구현
        - MemberRepository에 findByNickname, findByEmail 메서드 추가
- [ ] SignupRequest 클래스 명을 MemberRequest로 변경 (회원가입과 프로필 수정 시 모두 사용하기 위함)

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
