### PR TITLE
[Feat] 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/kotlin/team/b5/moviezip/MovieZipApplication.kt
+++ b/src/main/kotlin/team/b5/moviezip/MovieZipApplication.kt
@@ -3,9 +3,11 @@ package team.b5.moviezip
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 class MovieZipApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/team/b5/moviezip/member/controller/MemberController.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/controller/MemberController.kt
@@ -1,6 +1,7 @@
 package team.b5.moviezip.member.controller
 
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -23,4 +24,9 @@ class MemberController(
     @PutMapping("/members/{memberId}")
     fun update(@RequestBody memberRequest: MemberRequest, @PathVariable memberId: Long) =
         ResponseEntity.ok().body(memberService.update(memberRequest, memberId))
+
+    // 회원 탈퇴
+    @DeleteMapping("/members/withdrawal/{memberId}")
+    fun withdrawal(@PathVariable memberId: Long) =
+        ResponseEntity.ok().body(memberService.withdrawal(memberId))
 }

--- a/src/main/kotlin/team/b5/moviezip/member/model/Member.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/model/Member.kt
@@ -25,17 +25,24 @@ class Member(
 
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
-    val status: MemberStatus
+    var status: MemberStatus
 ) : BaseEntity() {
     @Id
     @Column(name = "member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
 
+    // 프로필 수정
     fun update(memberRequest: MemberRequest) {
         this.name = memberRequest.name
         this.email = memberRequest.email
         this.nickname = memberRequest.nickname
         this.password = memberRequest.password
+    }
+
+    // 회원 탈퇴를 위한 상태 변경
+    fun updateForWithdrawal() {
+        this.nickname = "탈퇴한 회원"
+        this.status = MemberStatus.WITHDRAWN
     }
 }

--- a/src/main/kotlin/team/b5/moviezip/member/service/MemberService.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/service/MemberService.kt
@@ -34,6 +34,9 @@ class MemberService(
         else if (memberRequest.password != memberRequest.password2) throw Exception("") // TODO
     }
 
+    // 회원 탈퇴
+    fun withdrawal(memberId: Long) = getMember(memberId).updateForWithdrawal()
+
     // 프로필 수정 시 검증 (본인이 기존에 사용하던 nickname, email은 검증 대상에서 제외)
     private fun validateRequest(memberRequest: MemberRequest, memberId: Long) {
         if (memberRepository.existsByNickname(memberRequest.nickname) && memberRepository.findByNickname(memberRequest.nickname).id != memberId)

--- a/src/main/kotlin/team/b5/moviezip/member/service/MemberService.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/service/MemberService.kt
@@ -1,11 +1,14 @@
 package team.b5.moviezip.member.service
 
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.b5.moviezip.member.dto.request.MemberRequest
+import team.b5.moviezip.member.model.MemberStatus
 import team.b5.moviezip.member.repository.MemberRepository
+import java.time.ZonedDateTime
 
 @Service
 @Transactional
@@ -34,8 +37,16 @@ class MemberService(
         else if (memberRequest.password != memberRequest.password2) throw Exception("") // TODO
     }
 
-    // 회원 탈퇴
+    // 회원 탈퇴 (신청)
     fun withdrawal(memberId: Long) = getMember(memberId).updateForWithdrawal()
+
+    // 회원 탈퇴 여부를 10초에 한 번씩 확인
+    @Scheduled(fixedDelay = 1000 * 10)
+    fun checkWithdrawal() =
+        memberRepository.findAll()
+            .filter {
+                it.status == MemberStatus.WITHDRAWN && it.updatedAt.plusDays(90) < ZonedDateTime.now()
+            }.map { memberRepository.delete(it) }
 
     // 프로필 수정 시 검증 (본인이 기존에 사용하던 nickname, email은 검증 대상에서 제외)
     private fun validateRequest(memberRequest: MemberRequest, memberId: Long) {


### PR DESCRIPTION
## 연관된 이슈

#18 

## 작업 내용

- [ ] MemberController와 MemberService에 withdrawal 메서드 생성
- [ ] Member 엔티티에 updateForWithdrawal 메서드 생성 (soft delete를 위함)
- [ ] 탈퇴 신청 후 90일이 지난 회원의 정보를 DB에서 삭제하는 로직 구현
        - MemberService에서  checkWithdrawal 메서드 생성 후 Scheduled 어노테이션 명시
        - 10초에 한 번씩 모든 회원에 대한 탈퇴 여부 체크
        - 스케줄링 적용 (메인 애플리케이션 클래스에 EnableScheduling 어노테이션 명시)

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
