### PR TITLE
[Feat] email 찾기 기능 구현

### DIFF
--- a/src/main/kotlin/team/b5/moviezip/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/b5/moviezip/global/config/SecurityConfig.kt
@@ -23,7 +23,8 @@ class SecurityConfig {
                     "/h2-console/**",
                     "/swagger-ui/**",
                     "/v3/api-docs/**",
-                    "/signup"
+                    "/signup",
+                    "/members/find-email",
                 ).permitAll()
                     .anyRequest().authenticated()
             }

--- a/src/main/kotlin/team/b5/moviezip/global/util/EmailEncoder.kt
+++ b/src/main/kotlin/team/b5/moviezip/global/util/EmailEncoder.kt
@@ -1,0 +1,12 @@
+package team.b5.moviezip.global.util
+
+object EmailEncoder {
+    fun encode(email: String) =
+        email.substring(0, email.indexOf('@'))
+            .let {
+                if (it.length >= 10)
+                    email.replaceRange(it.length / 2 - 2, it.length / 2 + 2, "*****")
+                else
+                    email.replaceRange(it.length / 2 - 1, it.length / 2 + 1, "***")
+            }
+}

--- a/src/main/kotlin/team/b5/moviezip/member/controller/MemberController.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/controller/MemberController.kt
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
+import team.b5.moviezip.member.dto.request.FindEmailRequest
 import team.b5.moviezip.member.dto.request.MemberRequest
 import team.b5.moviezip.member.service.MemberService
 import java.net.URI
@@ -23,4 +24,9 @@ class MemberController(
     @PutMapping("/members/{memberId}")
     fun update(@RequestBody memberRequest: MemberRequest, @PathVariable memberId: Long) =
         ResponseEntity.ok().body(memberService.update(memberRequest, memberId))
+
+    // 이메일 찾기
+    @PostMapping("/members/find-email")
+    fun findEmail(@RequestBody findEmailRequest: FindEmailRequest) =
+        ResponseEntity.ok().body(memberService.findEmail(findEmailRequest))
 }

--- a/src/main/kotlin/team/b5/moviezip/member/dto/request/FindEmailRequest.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/dto/request/FindEmailRequest.kt
@@ -1,0 +1,16 @@
+package team.b5.moviezip.member.dto.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
+data class FindEmailRequest(
+    @field:NotBlank(message = "사용자 이름은 필수 항목입니다.")
+    val name: String,
+
+    @field:NotBlank(message = "핸드폰 번호는 필수 항목입니다.")
+    @field:Pattern(
+        regexp = "^010-?([0-9]{3,4})-?([0-9]{4})$",
+        message = "올바른 휴대폰 번호 형식이 아닙니다."
+    )
+    val phone: String
+)

--- a/src/main/kotlin/team/b5/moviezip/member/dto/request/MemberRequest.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/dto/request/MemberRequest.kt
@@ -19,6 +19,13 @@ data class MemberRequest(
     @field:Email(message = "올바른 이메일 형식이 아닙니다.")
     val email: String,
 
+    @field:NotBlank(message = "핸드폰 번호는 필수 항목입니다.")
+    @field:Pattern(
+        regexp = "^010-?([0-9]{3,4})-?([0-9]{4})$",
+        message = "올바른 휴대폰 번호 형식이 아닙니다."
+    )
+    val phone: String,
+
     @field:NotBlank(message = "비밀번호는 필수 항목입니다.")
     @field:Pattern(
         regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&+=]).{8,16}$",
@@ -34,6 +41,7 @@ data class MemberRequest(
         name = name,
         nickname = nickname,
         email = email,
+        phone = phone,
         password = passwordEncoder.encode(password),
         status = MemberStatus.NORMAL,
     )

--- a/src/main/kotlin/team/b5/moviezip/member/model/Member.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/model/Member.kt
@@ -20,6 +20,9 @@ class Member(
     @Column(name = "email", nullable = false)
     var email: String,
 
+    @Column(name = "phone", nullable = false)
+    var phone: String,
+
     @Column(name = "password", nullable = false)
     var password: String,
 

--- a/src/main/kotlin/team/b5/moviezip/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/repository/MemberRepository.kt
@@ -10,4 +10,5 @@ interface MemberRepository : JpaRepository<Member, Long> {
     fun existsByEmail(email: String): Boolean
     fun findByNickname(nickname: String): Member
     fun findByEmail(email: String): Member
+    fun findByNameAndPhone(name: String, phone: String): Member?
 }

--- a/src/main/kotlin/team/b5/moviezip/member/service/MemberService.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/service/MemberService.kt
@@ -4,6 +4,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.b5.moviezip.member.dto.request.FindEmailRequest
 import team.b5.moviezip.member.dto.request.MemberRequest
 import team.b5.moviezip.member.repository.MemberRepository
 
@@ -19,6 +20,10 @@ class MemberService(
             validateRequest(it)
             memberRepository.save(it.to(passwordEncoder))
         }
+
+    // 이메일 찾기
+    fun findEmail(findEmailRequest: FindEmailRequest) =
+        getMember(findEmailRequest.name, findEmailRequest.phone).email
 
     // 프로필 수정
     fun update(memberRequest: MemberRequest, memberId: Long) =
@@ -43,7 +48,11 @@ class MemberService(
         else if (memberRequest.password != memberRequest.password2) throw Exception("") // TODO
     }
 
-    // 회원 조회
+    // 회원 조회 (memberId)
     private fun getMember(memberId: Long) =
         memberRepository.findByIdOrNull(memberId) ?: throw Exception("") // TODO
+
+    // 회원 조회 (name, phone)
+    private fun getMember(name: String, phone: String) =
+        memberRepository.findByNameAndPhone(name, phone) ?: throw Exception("") // TODO
 }

--- a/src/main/kotlin/team/b5/moviezip/member/service/MemberService.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/service/MemberService.kt
@@ -5,6 +5,7 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.b5.moviezip.global.util.EmailEncoder
 import team.b5.moviezip.member.dto.request.FindEmailRequest
 import team.b5.moviezip.member.dto.request.MemberRequest
 import team.b5.moviezip.member.model.MemberStatus
@@ -27,17 +28,19 @@ class MemberService(
 
     // 프로필 조회
     fun findMember(memberId: Long) = MemberResponse.from(getMember(memberId))
-    
+
     // 프로필 수정
     fun update(memberRequest: MemberRequest, memberId: Long) =
         memberRequest.let {
             validateRequest(it, memberId)
             getMember(memberId).update(it)
         }
-    
+
     // 이메일 찾기
     fun findEmail(findEmailRequest: FindEmailRequest) =
-        getMember(findEmailRequest.name, findEmailRequest.phone).email
+        EmailEncoder.encode(
+            email = getMember(findEmailRequest.name, findEmailRequest.phone).email
+        )
 
     // 회원가입 검증
     private fun validateRequest(memberRequest: MemberRequest) {


### PR DESCRIPTION
## 연관된 이슈

#20 

## 작업 내용

- [ ] Member 엔티티에 phone 속성 추가
        - 관련 클래스/메서드 로직 수정
- [ ] 이메일 찾기를 위해 사용자로부터 name, phone을 입력받는 FindEmailRequest 클래스 생성
- [ ] MemberController, MemberService에 findEmail 메서드 생성
- [ ] MemberRepository에 findByNameAndPhone 메서드 생성
- [ ] 이메일의 id부분의 일부를 *로 가리는 로직을 구현
        - EmailEncoder Object를 생성 후 encode 메서드 생성
        - MemberService의 findEmail 메서드에 적용
- [ ] SecurityConfig에 이메일 찾기 API에 권한 예외 설정 (members/find-email)

## 리뷰 요구사항 (선택)

Member 엔티티에 phone 속성이 추가되었습니다! 다들 확인해주세용
