### PR TITLE
[Feat] 예외 처리 핸들러 생성 및 예외 케이스 3건 추가

### DIFF
--- a/src/main/kotlin/team/b5/moviezip/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/team/b5/moviezip/global/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,66 @@
+package team.b5.moviezip.global.exception
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import team.b5.moviezip.global.exception.case.DuplicatedValueException
+import team.b5.moviezip.global.exception.case.ModelNotFoundException
+import team.b5.moviezip.global.exception.case.PasswordMismatchException
+import team.b5.moviezip.global.exception.dto.ErrorResponse
+
+@RestControllerAdvice
+class GlobalExceptionHandler(
+    private val httpServletRequest: HttpServletRequest
+) {
+    // 특정 엔티티 조회 실패
+    @ExceptionHandler(ModelNotFoundException::class)
+    fun handleModelNotFoundException(e: ModelNotFoundException) =
+        ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+            ErrorResponse(
+                httpStatus = "404 Not Found",
+                message = e.message.toString(),
+                path = httpServletRequest.requestURI
+            )
+        )
+
+    // 중복값 존재
+    @ExceptionHandler(DuplicatedValueException::class)
+    fun handleDuplicatedValueException(e: DuplicatedValueException) =
+        ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+            ErrorResponse(
+                httpStatus = "400 Bad Request",
+                message = e.message.toString(),
+                path = httpServletRequest.requestURI
+            )
+        )
+
+    // 비밀번호 불일치
+    @ExceptionHandler(PasswordMismatchException::class)
+    fun handlePasswordMismatchException(e: PasswordMismatchException) =
+        ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+            ErrorResponse(
+                httpStatus = "400 Bad Request",
+                message = e.message.toString(),
+                path = httpServletRequest.requestURI
+            )
+        )
+
+    // Validation 미통과
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException) =
+        ResponseEntity.badRequest().body(
+            ErrorResponse(
+                httpStatus = "400 Bad Request",
+                message = e.bindingResult.allErrors.toMutableList().first().defaultMessage!!,
+                path = httpServletRequest.requestURI.toString(),
+                errorContent = e.bindingResult.allErrors.toMutableList().first().let {
+                    it as FieldError
+                    it.field
+                }
+            )
+        )
+}

--- a/src/main/kotlin/team/b5/moviezip/global/exception/case/DuplicatedValueException.kt
+++ b/src/main/kotlin/team/b5/moviezip/global/exception/case/DuplicatedValueException.kt
@@ -1,0 +1,4 @@
+package team.b5.moviezip.global.exception.case
+
+class DuplicatedValueException(value: String) :
+    RuntimeException("이미 존재하는 $value 입니다.")

--- a/src/main/kotlin/team/b5/moviezip/global/exception/case/ModelNotFoundException.kt
+++ b/src/main/kotlin/team/b5/moviezip/global/exception/case/ModelNotFoundException.kt
@@ -1,0 +1,4 @@
+package team.b5.moviezip.global.exception.case
+
+class ModelNotFoundException(value: String) :
+    RuntimeException("해당 ${value}을 찾을 수 없습니다.")

--- a/src/main/kotlin/team/b5/moviezip/global/exception/case/PasswordMismatchException.kt
+++ b/src/main/kotlin/team/b5/moviezip/global/exception/case/PasswordMismatchException.kt
@@ -1,0 +1,4 @@
+package team.b5.moviezip.global.exception.case
+
+class PasswordMismatchException :
+    RuntimeException("비밀번호가 일치하지 않습니다. 다시 입력해주세요.")

--- a/src/main/kotlin/team/b5/moviezip/global/exception/dto/ErrorResponse.kt
+++ b/src/main/kotlin/team/b5/moviezip/global/exception/dto/ErrorResponse.kt
@@ -1,0 +1,16 @@
+package team.b5.moviezip.global.exception.dto
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.LocalDateTime
+
+data class ErrorResponse(
+    @JsonProperty("http_status")
+    val httpStatus: String,
+    val message: String,
+    val path: String,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    val time: LocalDateTime = LocalDateTime.now(),
+    @JsonProperty("error_content")
+    val errorContent: String? = null
+)


### PR DESCRIPTION
## 연관된 이슈

#23 

## 작업 내용

- [ ] 모든 커스텀 Exception들을 조작하는 GlobalExceptionHandler 클래스 생성
- [ ] 예외 케이스 3건 추가
        - ModelNotFoundException : 엔티티 조회에 실패하는 경우
        - DuplicatedValueException : (특히 회원가입 시) 중복된 닉네임, 이메일을 가지는 경우
        - PasswordMismatchException : 패스워드가 일치하지 않는 경우
- [ ] MemberService 내에 TODO로 남겨둔 예외 처리 로직 구현

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
