### PR TITLE
[Feat] 최근 3번 안에 사용한 비밀번호는 사용할 수 없도록 제한하는 로직 구현

### DIFF
--- a/src/main/kotlin/team/b5/moviezip/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/team/b5/moviezip/global/exception/GlobalExceptionHandler.kt
@@ -7,10 +7,7 @@ import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
-import team.b5.moviezip.global.exception.case.DuplicatedLikeException
-import team.b5.moviezip.global.exception.case.DuplicatedValueException
-import team.b5.moviezip.global.exception.case.ModelNotFoundException
-import team.b5.moviezip.global.exception.case.PasswordMismatchException
+import team.b5.moviezip.global.exception.case.*
 import team.b5.moviezip.global.exception.dto.ErrorResponse
 
 @RestControllerAdvice
@@ -42,6 +39,17 @@ class GlobalExceptionHandler(
     // 비밀번호 불일치
     @ExceptionHandler(PasswordMismatchException::class)
     fun handlePasswordMismatchException(e: PasswordMismatchException) =
+        ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+            ErrorResponse(
+                httpStatus = "400 Bad Request",
+                message = e.message.toString(),
+                path = httpServletRequest.requestURI
+            )
+        )
+
+    // 비밀번호 재사용
+    @ExceptionHandler(AlreadyUsedPasswordException::class)
+    fun handleAlreadyUsedPasswordException(e: AlreadyUsedPasswordException) =
         ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
             ErrorResponse(
                 httpStatus = "400 Bad Request",

--- a/src/main/kotlin/team/b5/moviezip/global/exception/case/AlreadyUsedPasswordException.kt
+++ b/src/main/kotlin/team/b5/moviezip/global/exception/case/AlreadyUsedPasswordException.kt
@@ -1,0 +1,4 @@
+package team.b5.moviezip.global.exception.case
+
+class AlreadyUsedPasswordException :
+    RuntimeException("이전에 사용한 패스워드를 재사용할 수 없습니다.")

--- a/src/main/kotlin/team/b5/moviezip/member/controller/MemberController.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/controller/MemberController.kt
@@ -9,9 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
-import team.b5.moviezip.member.dto.request.FindEmailRequest
-import team.b5.moviezip.member.dto.request.MemberLoginRequest
-import team.b5.moviezip.member.dto.request.MemberRequest
+import team.b5.moviezip.member.dto.request.*
 import team.b5.moviezip.member.dto.response.MemberLoginResponse
 import team.b5.moviezip.member.service.MemberService
 import java.net.URI
@@ -22,18 +20,23 @@ class MemberController(
 ) {
     // 회원가입
     @PostMapping("/signup")
-    fun signup(@RequestBody memberRequest: MemberRequest) =
-        ResponseEntity.created(URI.create("/")).body(memberService.signup(memberRequest))
+    fun signup(@RequestBody signupRequest: SignupRequest) =
+        ResponseEntity.created(URI.create("/")).body(memberService.signup(signupRequest))
 
     // 프로필 조회
     @GetMapping("/members/{memberId}")
     fun findMember(@PathVariable memberId: Long) =
         ResponseEntity.ok().body(memberService.findMember(memberId))
-        
+
     // 프로필 수정
-    @PutMapping("/members/{memberId}")
-    fun update(@RequestBody memberRequest: MemberRequest, @PathVariable memberId: Long) =
-        ResponseEntity.ok().body(memberService.update(memberRequest, memberId))
+    @PutMapping("/members/edit-profile/{memberId}")
+    fun update(@RequestBody editProfileRequest: EditProfileRequest, @PathVariable memberId: Long) =
+        ResponseEntity.ok().body(memberService.updateProfile(editProfileRequest, memberId))
+
+    // 비밀번호 변경
+    @PutMapping("/members/edit-password/{memberId}")
+    fun update(@RequestBody passwordRequest: EditPasswordRequest, @PathVariable memberId: Long) =
+        ResponseEntity.ok().body(memberService.updatePassword(passwordRequest, memberId))
 
     // 로그인
     @PostMapping("/login")
@@ -42,6 +45,7 @@ class MemberController(
             .status(HttpStatus.OK)
             .body(memberService.login(memberLoginRequest))
     }
+
     // 이메일 찾기
     @PostMapping("/members/find-email")
     fun findEmail(@RequestBody findEmailRequest: FindEmailRequest) =

--- a/src/main/kotlin/team/b5/moviezip/member/dto/request/EditPasswordRequest.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/dto/request/EditPasswordRequest.kt
@@ -1,0 +1,19 @@
+package team.b5.moviezip.member.dto.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
+data class EditPasswordRequest(
+    @field:NotBlank(message = "현재 비밀번호는 입력해주세요.")
+    val currentPassword: String,
+
+    @field:NotBlank(message = "비밀번호는 필수 항목입니다.")
+    @field:Pattern(
+        regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&+=]).{8,16}$",
+        message = "비밀번호는 영문과 특수문자 숫자를 포함하며 8자 이상 16자 이하여야 합니다"
+    )
+    val newPassword: String,
+
+    @field:NotBlank(message = "비밀번호를 다시 한 번 입력해주세요.")
+    val newPassword2: String,
+)

--- a/src/main/kotlin/team/b5/moviezip/member/dto/request/EditProfileRequest.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/dto/request/EditProfileRequest.kt
@@ -1,0 +1,35 @@
+package team.b5.moviezip.member.dto.request
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import org.springframework.security.crypto.password.PasswordEncoder
+import team.b5.moviezip.member.model.Member
+import team.b5.moviezip.member.model.MemberRole
+import team.b5.moviezip.member.model.MemberStatus
+
+data class EditProfileRequest(
+    @field:NotBlank(message = "사용자 이름은 필수 항목입니다.")
+    val name: String,
+
+    @field:NotBlank(message = "닉네임은 필수 항목입니다.")
+    val nickname: String,
+
+    @field:NotBlank(message = "이메일은 필수 항목입니다.")
+    @field:Email(message = "올바른 이메일 형식이 아닙니다.")
+    val email: String,
+
+    @field:NotBlank(message = "핸드폰 번호는 필수 항목입니다.")
+    @field:Pattern(
+        regexp = "^010-?([0-9]{3,4})-?([0-9]{4})$",
+        message = "올바른 휴대폰 번호 형식이 아닙니다."
+    )
+    val phone: String,
+
+    @field:NotBlank(message = "비밀번호는 필수 항목입니다.")
+    @field:Pattern(
+        regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&+=]).{8,16}$",
+        message = "비밀번호는 영문과 특수문자 숫자를 포함하며 8자 이상 16자 이하여야 합니다"
+    )
+    val password: String
+)

--- a/src/main/kotlin/team/b5/moviezip/member/dto/request/SignupRequest.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/dto/request/SignupRequest.kt
@@ -8,7 +8,7 @@ import team.b5.moviezip.member.model.Member
 import team.b5.moviezip.member.model.MemberRole
 import team.b5.moviezip.member.model.MemberStatus
 
-data class MemberRequest(
+data class SignupRequest(
     @field:NotBlank(message = "사용자 이름은 필수 항목입니다.")
     val name: String,
 
@@ -44,5 +44,6 @@ data class MemberRequest(
         phone = phone,
         password = passwordEncoder.encode(password),
         status = MemberStatus.NORMAL,
+        passwordHistory = passwordEncoder.encode(password)
     )
 }

--- a/src/main/kotlin/team/b5/moviezip/member/model/Member.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/model/Member.kt
@@ -1,8 +1,9 @@
 package team.b5.moviezip.member.model
 
 import jakarta.persistence.*
+import org.springframework.security.crypto.password.PasswordEncoder
 import team.b5.moviezip.global.model.BaseEntity
-import team.b5.moviezip.member.dto.request.MemberRequest
+import team.b5.moviezip.member.dto.request.EditProfileRequest
 
 @Entity
 @Table(name = "Members")
@@ -26,6 +27,9 @@ class Member(
     @Column(name = "password", nullable = false)
     var password: String,
 
+    @Column(name = "password_history", nullable = false)
+    var passwordHistory: String,
+
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
     var status: MemberStatus
@@ -36,11 +40,17 @@ class Member(
     val id: Long? = null
 
     // 프로필 수정
-    fun update(memberRequest: MemberRequest) {
-        this.name = memberRequest.name
-        this.email = memberRequest.email
-        this.nickname = memberRequest.nickname
-        this.password = memberRequest.password
+    fun update(editProfileRequest: EditProfileRequest) {
+        this.name = editProfileRequest.name
+        this.email = editProfileRequest.email
+        this.nickname = editProfileRequest.nickname
+        this.phone = editProfileRequest.phone
+    }
+
+    // 비밀번호 변경
+    fun update(newPassword: String, passwordHistory: String, passwordEncoder: PasswordEncoder) {
+        this.password = passwordEncoder.encode(newPassword)
+        this.passwordHistory = passwordHistory
     }
 
     // 회원 탈퇴를 위한 상태 변경

--- a/src/main/kotlin/team/b5/moviezip/member/service/MemberService.kt
+++ b/src/main/kotlin/team/b5/moviezip/member/service/MemberService.kt
@@ -5,19 +5,19 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.b5.moviezip.global.exception.case.AlreadyUsedPasswordException
 import team.b5.moviezip.global.exception.case.DuplicatedValueException
 import team.b5.moviezip.global.exception.case.ModelNotFoundException
 import team.b5.moviezip.global.exception.case.PasswordMismatchException
 import team.b5.moviezip.global.util.EmailEncoder
-import team.b5.moviezip.member.dto.request.FindEmailRequest
 import team.b5.moviezip.global.security.jwt.JwtPlugin
-import team.b5.moviezip.member.dto.request.MemberLoginRequest
-import team.b5.moviezip.member.dto.request.MemberRequest
+import team.b5.moviezip.member.dto.request.*
 import team.b5.moviezip.member.dto.response.MemberLoginResponse
 import team.b5.moviezip.member.model.MemberStatus
 import team.b5.moviezip.member.dto.response.MemberResponse
 import team.b5.moviezip.member.repository.MemberRepository
 import java.time.ZonedDateTime
+import java.util.LinkedList
 
 @Service
 @Transactional
@@ -27,15 +27,15 @@ class MemberService(
     private val jwtPlugin: JwtPlugin
 ) {
     // 회원가입
-    fun signup(memberRequest: MemberRequest) =
-        memberRequest.let {
+    fun signup(signupRequest: SignupRequest) =
+        signupRequest.let {
             validateRequest(it)
             memberRepository.save(it.to(passwordEncoder))
         }
-        
+
     // 프로필 조회
     fun findMember(memberId: Long) = MemberResponse.from(getMember(memberId))
-    
+
     // 이메일 찾기
     fun findEmail(findEmailRequest: FindEmailRequest) =
         EmailEncoder.encode(
@@ -43,10 +43,20 @@ class MemberService(
         )
 
     // 프로필 수정
-    fun update(memberRequest: MemberRequest, memberId: Long) =
-        memberRequest.let {
+    fun updateProfile(editProfileRequest: EditProfileRequest, memberId: Long) =
+        editProfileRequest.let {
             validateRequest(it, memberId)
             getMember(memberId).update(it)
+        }
+
+    // 비밀번호 변경
+    fun updatePassword(editPasswordRequest: EditPasswordRequest, memberId: Long) =
+        editPasswordRequest.let {
+            getMember(memberId).update(
+                newPassword = it.newPassword,
+                passwordHistory = validatePassword(memberId, it.currentPassword, it.newPassword),
+                passwordEncoder = passwordEncoder
+            )
         }
 
     // 회원 탈퇴 (신청)
@@ -80,23 +90,46 @@ class MemberService(
         )
     }
 
-    // 회원가입 검증
-    private fun validateRequest(memberRequest: MemberRequest) {
-        if (memberRepository.existsByNickname(memberRequest.nickname)) throw DuplicatedValueException("닉네임")
-        else if (memberRepository.existsByEmail(memberRequest.email)) throw DuplicatedValueException("이메일")
-        else if (memberRequest.password != memberRequest.password2) throw PasswordMismatchException()
+    // 회원가입 시 검증
+    private fun validateRequest(signupRequest: SignupRequest) {
+        if (memberRepository.existsByNickname(signupRequest.nickname)) throw DuplicatedValueException("닉네임")
+        else if (memberRepository.existsByEmail(signupRequest.email)) throw DuplicatedValueException("이메일")
+        else if (signupRequest.password != signupRequest.password2) throw PasswordMismatchException()
     }
 
     // 프로필 수정 시 검증 (본인이 기존에 사용하던 nickname, email은 검증 대상에서 제외)
-    private fun validateRequest(memberRequest: MemberRequest, memberId: Long) {
-        if (memberRepository.existsByNickname(memberRequest.nickname)
-            && getMemberByNickname(memberRequest.nickname).id != memberId
+    private fun validateRequest(editProfileRequest: EditProfileRequest, memberId: Long) {
+        if (memberRepository.existsByNickname(editProfileRequest.nickname)
+            && getMemberByNickname(editProfileRequest.nickname).id != memberId
         ) throw DuplicatedValueException("닉네임")
-        else if (memberRepository.existsByEmail(memberRequest.email)
-            && getMemberByEmail(memberRequest.email).id != memberId
+        else if (memberRepository.existsByEmail(editProfileRequest.email)
+            && getMemberByEmail(editProfileRequest.email).id != memberId
         ) throw DuplicatedValueException("이메일")
-        else if (memberRequest.password != memberRequest.password2) throw PasswordMismatchException()
+        else if (!passwordEncoder.matches(
+                editProfileRequest.password, getMember(memberId).password
+            )
+        ) throw PasswordMismatchException()
     }
+
+    // 비밀번호 변경 시 검증
+    private fun validatePassword(memberId: Long, currentPassword: String, newPassword: String) =
+        LinkedList<String>().let { queue ->
+            (getMember(memberId).passwordHistory.split(" ")).forEach { queue.add(it) }
+            if (!passwordEncoder.matches(currentPassword, getMember(memberId).password))
+                throw PasswordMismatchException()
+            else if (queue.any { encodedPassword ->
+                    passwordEncoder.matches(newPassword, encodedPassword)
+                }) throw AlreadyUsedPasswordException()
+            else if (queue.size < 3) {
+                queue.add(passwordEncoder.encode(newPassword))
+                queue.joinToString(" ")
+            }
+            else {
+                queue.remove()
+                queue.add(passwordEncoder.encode(newPassword))
+                queue.joinToString(" ")
+            }
+        }
 
     // 회원 조회 (memberId)
     private fun getMember(memberId: Long) =


### PR DESCRIPTION
## 연관된 이슈

#47 

## 작업 내용

- [ ] 프로필 수정과 비밀번호 변경 로직을 분리
        - MemberRequest를 SignupRequest와 EditProfileRequest로 분리
        - MemberController와 MemberService에 updatePassword 메서드 생성
- [ ] MemberService에 password 히스토리를 검사하는 validatePassword 메서드 생성
- [ ] Member 엔티티에 passwordHistory 속성 추가
        - 최근 3번간 사용한 비밀번호를 구분자 " "를 통해 하나의 문자열로 연결하여 DB에 저장
- [ ] 예외 케이스 1건 추가 (AlreadyUsedPasswordException)

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
