### PR TITLE
[Feat] Movie의 status를 구분하는 로직 구현

### DIFF
--- a/src/main/kotlin/team/b5/moviezip/movie/model/Movie.kt
+++ b/src/main/kotlin/team/b5/moviezip/movie/model/Movie.kt
@@ -53,7 +53,7 @@ class Movie(
 
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
-    val status: MovieStatus,
+    var status: MovieStatus,
 
     @ManyToMany
     val like: MutableSet<Member>,
@@ -72,5 +72,9 @@ class Movie(
 
     fun dislike(member: Member) {
         this.dislike.add(member)
+    }
+
+    fun updateStatus(status: MovieStatus) {
+        this.status = status
     }
 }


### PR DESCRIPTION
## 연관된 이슈

#64

## 작업 내용

- [ ] 초기에 Movie 데이터 등록 시 status를 판단하는 getMovieStatus 메서드
- [ ] Scheduled 어노테이션을 활용하여 개방 철회 여부를 하루에 한 번씩 확인
        - 개봉일 기준 45일이 지난 영화의 stauts를 NORMAL로 변경
- [ ] Movie 엔티티에 updateStatus 메서드 추가 (status를 변경)

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
