### PR TITLE
[BugFix] 초기 Movie 데이터 저장 시 발생하는 버그 수정

### DIFF
--- a/src/main/kotlin/team/b5/moviezip/global/service/DataInitService.kt
+++ b/src/main/kotlin/team/b5/moviezip/global/service/DataInitService.kt
@@ -30,7 +30,7 @@ class DataInitService(
     // 영화 추가 (더미 데이터)
     fun addMovies(request: AddMovieRequest) =
         request.let {
-            if (!invalidateData(request.toArray(), null))
+            if (!isInvalidData(request.toArray(), null))
                 movieRepository.save(dataToEntity(request.toArray()))
         }
 
@@ -46,7 +46,7 @@ class DataInitService(
         do {
             val data = csvReader.readNext()
             if (data != null)
-                if (invalidateData(data, movies)) continue
+                if (isInvalidData(data, movies)) continue
                 else movies.add(dataToEntity(data))
         } while (data != null)
 
@@ -74,19 +74,18 @@ class DataInitService(
             ageLimit = data[7], // TODO
             genre = data[8],
             director = data[9],
-            actor = data[10], // TODO
+            actor = data[10],
 
-            description = "",
+            description = "", // TODO
             ratings = 0.0,
             like = mutableSetOf(),
             dislike = mutableSetOf(),
         )
 
     // 데이터 검증
-    private fun invalidateData(data: Array<String>, movies: ArrayList<Movie>?) =
-        movies?.any { it.name == data[0] && it.releaseAt == convertStringDateFromZonedDateTime(data[1]) } ?: false
-                || data[0].isEmpty()
-                || data[1].isEmpty()
+    private fun isInvalidData(data: Array<String>, movies: ArrayList<Movie>?) =
+        data[0].isEmpty() || data[1].isEmpty()
+                || movies?.any { it.name == data[0] && it.releaseAt == convertStringDateFromZonedDateTime(data[1]) } ?: false
                 || data[2].isEmpty() || data[2].replace(",", "").toLongOrNull() == null
                 || data[3].isEmpty() || data[3].replace(",", "").toLongOrNull() == null
                 || data[4].isEmpty() || data[4].replace(",", "").toIntOrNull() == null
@@ -107,8 +106,8 @@ class DataInitService(
     private fun getMovieStatus(releaseAt: String) =
         convertStringDateFromZonedDateTime(releaseAt)
             .let {
-                if (ZonedDateTime.now() > it) MovieStatus.TO_BE_RELEASED
-                else if (ZonedDateTime.now() > it.plusDays(45)) MovieStatus.RELEASED
+                if (ZonedDateTime.now() < it) MovieStatus.TO_BE_RELEASED
+                else if (ZonedDateTime.now() < it.plusDays(45)) MovieStatus.RELEASED
                 else MovieStatus.NORMAL
             }
 

--- a/src/main/kotlin/team/b5/moviezip/movie/model/Movie.kt
+++ b/src/main/kotlin/team/b5/moviezip/movie/model/Movie.kt
@@ -48,7 +48,7 @@ class Movie(
     var ratings: Double = 0.0,
 
     @Column(name = "search_count")
-    var searchCount: Long? = 0,
+    var searchCount: Long = 0,
 
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
@@ -75,5 +75,9 @@ class Movie(
 
     fun updateStatus(status: MovieStatus) {
         this.status = status
+    }
+
+    fun updateSearchCount() {
+        this.searchCount++
     }
 }


### PR DESCRIPTION
## 연관된 이슈

#73 

## 작업 내용

- [ ] 데이터를 검증할 때(invalidateData) 비교 로직 변경
        - 영화 중복 여부를 name 뿐만 아니라 releaseAt까지 검증
        - name과 releaseAt의 값 존재 여부를 비교한 다음, 영화 중복 여부를 검증
- [ ] status를 구분하는 기준 (개봉일과 현재 날짜 비교) 수정
- [ ] 특정 검색어에 해당하는 Movie 조회 시, 인기검색어(HotKeyword)에 저장하는 로직 구현
- [ ] 특정 검색어에 해당하는 Movie 조회 시, 검색 횟수(searchCount)를 1씩 증가하는 메서드 생성
- [ ] MovieController에서 페이징 관련 정보(page, sort)를 파라미터로 직접 받도록 설정

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
